### PR TITLE
correct DataLoader import in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --save nestjs-dataloader
 We start by implementing the ```NestDataLoader``` interface. This tells ```DataLoader``` how to load our objects.
 
 ``` typescript
-import DataLoader from 'dataloader';
+import * as DataLoader from 'dataloader';
 import { Injectable } from '@nestjs/common';
 import { NestDataLoader } from 'nestjs-dataloader';
 ...
@@ -61,7 +61,7 @@ export class ResolversModule { }
 ### Using the NestDataLoader
 Now that we have a dataloader and our module is aware of it, we need to pass it as a parameter to an endpoint in our graphQL resolver.
 ``` typescript
-import DataLoader from 'dataloader';
+import * as DataLoader from 'dataloader';
 import { Loader } from 'nestjs-dataloader';
 ...
 


### PR DESCRIPTION
Changes to README.md that will save developers time not having to chase an error introduced by following the code example in the README.md file

Using 
'''typescript
import DataLoader from 'dataloader'
'''
leads to the error: "TypeError: dataloader_1.default is not a constructor"
at the point where the generateDataLoader function is called.

changing to 

'''typescript
import * as DataLoader from 'dataloader' 
'''

fixes this issue