### PR TITLE
add context in generateDataLoader to configure the query based on req

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,9 +18,13 @@ import { Observable } from 'rxjs';
 export interface NestDataLoader<ID, Type> {
   /**
    * Should return a new instance of dataloader each time
-   * @params ctx: the execution context
+   * @params ctx: the graphql execution context
    */
   generateDataLoader(ctx: any): DataLoader<ID, Type>;
+    /**
+   * Should return a new instance of dataloader each time
+   */
+  generateDataLoader(): DataLoader<ID, Type>;
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -18,8 +18,9 @@ import { Observable } from 'rxjs';
 export interface NestDataLoader<ID, Type> {
   /**
    * Should return a new instance of dataloader each time
+   * @params ctx: the execution context
    */
-  generateDataLoader(): DataLoader<ID, Type>;
+  generateDataLoader(ctx: any): DataLoader<ID, Type>;
 }
 
 /**
@@ -49,7 +50,7 @@ export class DataLoaderInterceptor implements NestInterceptor {
           try {
             ctx[type] = this.moduleRef
               .get<NestDataLoader<any, any>>(type, { strict: false })
-              .generateDataLoader();
+              .generateDataLoader(ctx);
           } catch (e) {
             throw new InternalServerErrorException(`The loader ${type} is not provided`);
           }


### PR DESCRIPTION
This PR will allow to configure how we resolve data based not only on a list of ids but also with the current graphql context.