### PR TITLE
fix: type reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typeorm-factory": "^0.0.14",
     "typescript": "4.7.4"
   },
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
   "jest": {
     "transform": {
       "^.+\\.tsx?$": "ts-jest"


### PR DESCRIPTION
Types seem to be broken in current release causing:
`Could not find a declaration file for module 'nestjs-dataloader'.`